### PR TITLE
Show labels for each PR

### DIFF
--- a/app/partials/settings.html
+++ b/app/partials/settings.html
@@ -21,6 +21,12 @@
                 Changes
               </label>
             </div>
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="settings.labels_column">
+                Labels
+              </label>
+            </div>
           </div>
         </div>
         <p ng-if="came_from">

--- a/app/partials/table.html
+++ b/app/partials/table.html
@@ -43,6 +43,7 @@
          <th class="state" title="Indicates whether it's currently mergeable">M*</th>
          <th class="state" title="Indicates its status">S*</th>
          <th class="changes" ng-if="use_changes">Changes</th>
+         <th class="labels" ng-if="use_labels">Labels</th>
      </tr>
      </thead>
      <tbody>
@@ -133,6 +134,11 @@
                 </a>
                 <font color="#55A532">+{{ pull._additions  | number:0 }}</font> /
                 <font color="#BD2C00">-{{ pull._deletions | number:0 }}</font>
+            </td>
+            <td ng-if="use_labels" class="labels">
+                <strong ng-repeat="label in pull._labels | orderBy:'name':false" style="background-color: #{{ label.color }}">
+                    {{ label.name }}
+                </strong>
             </td>
         </tr>
      </tbody>

--- a/app/static/main.css
+++ b/app/static/main.css
@@ -94,6 +94,16 @@ p.diff-stats {
 td.changes a {
     color: black;
 }
+td.labels strong {
+    display: inline-block;
+    padding: 3px 4px;
+    font-size: 11px;
+    font-weight: bold;
+    line-height: 1;
+    color: white;
+    border-radius: 2px;
+    box-shadow: 0px -1px 0px rgba(0, 0, 0, 0.12) inset;
+}
 
 @font-face{
   font-family:'octicons';


### PR DESCRIPTION
This adds an optional (default to hidden) column showing the labels attached to each PR. Could be useful for teams using specific labels to show PR status, such as "not ready" or "r+".

To test, look at `mozilla/zamboni`, there should be a few PRs with "not ready" or "r+" labels.